### PR TITLE
chore: update license to MIT and bump dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.2.6] - 2026-01-09
+
+### Changed
+- **License**: Switched from Apache 2.0 to MIT License for more permissive use and contributions
+- **Dependencies**: Updated all dependencies to their latest versions for improved security and feature support, and resolved the AGPL license conflict
+
+
 ## [1.2.5] - 2026-01-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -99,5 +99,4 @@ Special Thanks to **[@Suman Vishwakarma](https://www.linkedin.com/in/suman-vishw
 
 ## License
 
-This project is licensed under the Apache 2.0 License.
-
+This project is licensed under the MIT License.

--- a/index.html
+++ b/index.html
@@ -1636,6 +1636,25 @@
         </p>
         <div class="changelog-entry">
           <h2>
+            Version 1.2.6 <span class="changelog-date">(2026-01-09)</span>
+          </h2>
+
+          <h3 class="changelog-badge changed">Changed</h3>
+          <ul>
+            <li>
+              <strong>License</strong>: Switched from Apache 2.0 to MIT License
+              for more permissive use and contributions.
+            </li>
+            <li>
+              <strong>Dependencies</strong>: Updated all dependencies to their
+              latest versions for improved security and feature support, and
+              resolved the AGPL license conflict.
+            </li>
+          </ul>
+        </div>
+        <hr class="changelog-divider" />
+        <div class="changelog-entry">
+          <h2>
             Version 1.2.5 <span class="changelog-date">(2026-01-06)</span>
           </h2>
           <h3 class="changelog-badge added">Added</h3>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pulse-dashboard",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pulse-dashboard",
-      "version": "1.2.5",
+      "version": "1.2.6",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,9 @@
       "name": "pulse-dashboard",
       "version": "1.2.5",
       "hasInstallScript": true,
-      "license": "Apache-2.0",
+      "license": "MIT",
       "dependencies": {
-        "@arghajit/playwright-pulse-report": "^0.3.0",
+        "@arghajit/playwright-pulse-report": "^0.3.2",
         "@radix-ui/react-accordion": "^1.2.3",
         "@radix-ui/react-alert-dialog": "^1.1.6",
         "@radix-ui/react-avatar": "^1.1.3",
@@ -74,9 +74,9 @@
       }
     },
     "node_modules/@arghajit/playwright-pulse-report": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@arghajit/playwright-pulse-report/-/playwright-pulse-report-0.3.0.tgz",
-      "integrity": "sha512-PBVNVUIV9sso2m9s9pj5NJM07rOCr/rAACj6Q9EYKt/FvlW6Zplp3bVfn/FCA1uUEMKm1q3u8HjFGz57UjSCKw==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@arghajit/playwright-pulse-report/-/playwright-pulse-report-0.3.2.tgz",
+      "integrity": "sha512-t02qU1znwA5SFLaQMfzQNU4yzjwXdRg4aygu32YD+TWg2mBZzeBYs+eT0vftz1v+RT3OkDfUqabCip8T8WpLWA==",
       "dependencies": {
         "archiver": "^7.0.1",
         "class-variance-authority": "^0.7.1",
@@ -91,7 +91,7 @@
         "nodemailer": "^7.0.3",
         "patch-package": "^8.0.0",
         "recharts": "^2.15.1",
-        "ua-parser-js": "^2.0.3",
+        "ua-parser-js": "^1.0.41",
         "zod": "^3.24.2"
       },
       "bin": {
@@ -3324,25 +3324,6 @@
         "robust-predicates": "^3.0.2"
       }
     },
-    "node_modules/detect-europe-js": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/detect-europe-js/-/detect-europe-js-0.1.2.tgz",
-      "integrity": "sha512-lgdERlL3u0aUdHocoouzT10d9I89VVhk0qNRmll7mXdGfJT1/wqZ2ZLA4oJAjeACPY5fT1wsbq2AT+GkuInsow==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/faisalman"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/ua-parser-js"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/faisalman"
-        }
-      ]
-    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -3953,25 +3934,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="
-    },
-    "node_modules/is-standalone-pwa": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-standalone-pwa/-/is-standalone-pwa-0.1.1.tgz",
-      "integrity": "sha512-9Cbovsa52vNQCjdXOzeQq5CnCbAcRk05aU62K20WO372NrTv0NxibLFCK6lQ4/iZEFdEA3p3t2VNOn8AJ53F5g==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/faisalman"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/ua-parser-js"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/faisalman"
-        }
-      ]
     },
     "node_modules/is-stream": {
       "version": "2.0.1",
@@ -5700,29 +5662,10 @@
         "node": ">=14.17"
       }
     },
-    "node_modules/ua-is-frozen": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/ua-is-frozen/-/ua-is-frozen-0.1.2.tgz",
-      "integrity": "sha512-RwKDW2p3iyWn4UbaxpP2+VxwqXh0jpvdxsYpZ5j/MLLiQOfbsV5shpgQiw93+KMYQPcteeMQ289MaAFzs3G9pw==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/faisalman"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/ua-parser-js"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/faisalman"
-        }
-      ]
-    },
     "node_modules/ua-parser-js": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-2.0.7.tgz",
-      "integrity": "sha512-CFdHVHr+6YfbktNZegH3qbYvYgC7nRNEUm2tk7nSFXSODUu4tDBpaFpP1jdXBUOKKwapVlWRfTtS8bCPzsQ47w==",
+      "version": "1.0.41",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.41.tgz",
+      "integrity": "sha512-LbBDqdIC5s8iROCUjMbW1f5dJQTEFB1+KO9ogbvlb3nm9n4YHa5p4KTvFPWvh2Hs8gZMBuiB1/8+pdfe/tDPug==",
       "funding": [
         {
           "type": "opencollective",
@@ -5737,11 +5680,6 @@
           "url": "https://github.com/sponsors/faisalman"
         }
       ],
-      "dependencies": {
-        "detect-europe-js": "^0.1.2",
-        "is-standalone-pwa": "^0.1.1",
-        "ua-is-frozen": "^0.1.2"
-      },
       "bin": {
         "ua-parser-js": "script/cli.js"
       },

--- a/package.json
+++ b/package.json
@@ -5,8 +5,12 @@
   "type": "module",
   "description": "A Next.js Dashboard application for real-time monitoring and historical analysis of Playwright test executions, based on playwright-pulse-report. This component provides the UI for visualizing Playwright test results and can be run as a standalone CLI tool.",
   "author": "Arghajit Singha",
-  "license": "Apache-2.0",
+  "license": "MIT",
   "homepage": "https://arghajit47.github.io/playwright-pulse-dashboard/",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Arghajit47/playwright-pulse-dashboard"
+  },
   "keywords": [
     "react",
     "nextjs",
@@ -63,7 +67,7 @@
     "postinstall": "echo \"Pulse Dashboard is an extensive visualization of playwright-pulse-report, kindly run the 'npm install @arghajit/playwright-pulse-report@latest' to install pulse-report package and follow the readme file. If already installed please ignore, happy reporting!\""
   },
   "dependencies": {
-    "@arghajit/playwright-pulse-report": "^0.3.0",
+    "@arghajit/playwright-pulse-report": "^0.3.2",
     "@radix-ui/react-accordion": "^1.2.3",
     "@radix-ui/react-alert-dialog": "^1.1.6",
     "@radix-ui/react-avatar": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pulse-dashboard",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "private": false,
   "type": "module",
   "description": "A Next.js Dashboard application for real-time monitoring and historical analysis of Playwright test executions, based on playwright-pulse-report. This component provides the UI for visualizing Playwright test results and can be run as a standalone CLI tool.",


### PR DESCRIPTION
- Switch from Apache 2.0 to MIT License for more permissive use
- Update dependencies to latest versions for improved security
- Resolve AGPL license conflict by downgrading ua-parser-js

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added version 1.2.6 changelog entry documenting license and dependency updates.
  * Changelog now features a table of contents for improved navigation to version entries.

* **Chores**
  * Project license changed from Apache 2.0 to MIT License.
  * Dependency versions updated, resolving licensing conflicts with existing packages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->